### PR TITLE
Extend ABORT_ON_ENDSTOP_HIT to USB-printing

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -401,13 +401,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -229,6 +229,7 @@ void ok_to_send();
 
 void reset_bed_level();
 void kill(const char*);
+void stop();
 
 void quickstop_stepper();
 

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -401,13 +401,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -401,13 +401,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -401,13 +401,16 @@
   // This allows hosts to request long names for files and folders with M33
   #define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -407,13 +407,16 @@
   // This allows hosts to request long names for files and folders with M33
   #define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -401,13 +401,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -401,13 +401,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -409,13 +409,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -401,13 +401,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -403,13 +403,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -403,13 +403,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -402,13 +402,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -407,13 +407,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -403,13 +403,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -401,13 +401,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -401,13 +401,16 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define DEFAULT_ABORT_ON_ENDSTOP_HIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define DEFAULT_ABORT_ON_ENDSTOP_HIT true
+
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -83,7 +83,11 @@ class Stepper {
     static block_t* current_block;  // A pointer to the block currently being traced
 
     #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
-      static bool abort_on_endstop_hit;
+      #if defined(DEFAULT_ABORT_ON_ENDSTOP_HIT)
+        static bool abort_on_endstop_hit = DEFAULT_ABORT_ON_ENDSTOP_HIT;
+      #else
+        static bool abort_on_endstop_hit = false;
+      #endif
     #endif
 
     #if ENABLED(Z_DUAL_ENDSTOPS)


### PR DESCRIPTION
Added configurable option ABORT_ON_ENDSTOP_HIT_INIT to activate the feature at boot time.
Changes some descriptive text.
Cleaned up the use of enable_endstops() in homeaxis().
Changed the initialisation of abort_on_endstop_hit to relate on ABORT_ON_ENDSTOP_HIT_INIT.
Changed checkHitEndstops() to
throw an ERROR instead of an ECHO when ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED.
Send "X=" instead of "X:" also for Y,Z and probe to make the output not readable by Repetier Host.

Abort all printing when ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED. Therefor the already existent feature for sd-printing was extended.

To come out of the look send M999.
