### PR TITLE
Endstop setup/test

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -333,8 +333,25 @@ const bool X_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 const bool Y_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -229,6 +229,26 @@
  *
  */
 
+#define DEFINE_PGM_READ_ANY(type, reader)       \
+  static inline type pgm_read_any(const type *p)  \
+  { return pgm_read_##reader##_near(p); }
+
+DEFINE_PGM_READ_ANY(float,       float);
+DEFINE_PGM_READ_ANY(signed char, byte);
+
+#define XYZ_CONSTS_FROM_CONFIG(type, array, CONFIG) \
+  static const PROGMEM type array##_P[3] =        \
+      { X_##CONFIG, Y_##CONFIG, Z_##CONFIG };     \
+  static inline type array(int axis)          \
+  { return pgm_read_any(&array##_P[axis]); }
+
+XYZ_CONSTS_FROM_CONFIG(float, base_min_pos,   MIN_POS);
+XYZ_CONSTS_FROM_CONFIG(float, base_max_pos,   MAX_POS);
+XYZ_CONSTS_FROM_CONFIG(float, base_home_pos,  HOME_POS);
+XYZ_CONSTS_FROM_CONFIG(float, max_length,     MAX_LENGTH);
+XYZ_CONSTS_FROM_CONFIG(float, home_bump_mm,   HOME_BUMP_MM);
+XYZ_CONSTS_FROM_CONFIG(signed char, home_dir, HOME_DIR);
+
 #if ENABLED(M100_FREE_MEMORY_WATCHER)
   void gcode_M100();
 #endif
@@ -611,6 +631,110 @@ void servo_init() {
   void enableStepperDrivers() { pinMode(STEPPER_RESET_PIN, INPUT); }  // set to input, which allows it to be pulled high by pullups
 #endif
 
+#ifdef ENDSTOP_SELFTEST
+  void gcode_M119(); //forward declarations
+  void line_to_current_position();
+  void set_destination_to_current();
+
+  void endstop_test_error( char axis) {
+    SERIAL_ERROR_START;
+    SERIAL_ERRORPGM(" Both endstops triggered on axis: ");
+    SERIAL_ERRORLN(axis);
+    #if ENABLED(ULTRA_LCD)
+      lcd_setalertstatuspgm(PSTR("Error: ENDSTOP"));
+    #endif
+    gcode_M119();
+  }
+
+  void endstop_free_error( char axis) {
+    SERIAL_ERROR_START;
+    SERIAL_ERRORPGM(" Can not free endstop on axis: ");
+    SERIAL_ERRORLN(axis);
+    #if ENABLED(ULTRA_LCD)
+      lcd_setalertstatuspgm(PSTR("Error: ENDSTOP"));
+    #endif
+    gcode_M119();
+  }
+
+  void free_endstop(int axis, float dir) {
+    #if ENABLED(DELTA)
+      current_position[Z_AXIS] += home_bump_mm(axis) * dir;
+    #else
+      current_position[axis] += home_bump_mm(axis) * dir;
+    #endif
+    line_to_current_position();
+    st_synchronize();
+    set_destination_to_current();
+  }
+
+  void selftest_endstops() {
+    #if HAS_X_MIN && HAS_X_MAX
+      if ((READ(X_MIN_PIN)^X_MIN_ENDSTOP_INVERTING) && (READ(X_MAX_PIN)^X_MAX_ENDSTOP_INVERTING)) {
+        endstop_test_error('X');
+      }
+    #endif
+    #if HAS_Y_MIN && HAS_Y_MAX
+      if ((READ(Y_MIN_PIN)^Y_MIN_ENDSTOP_INVERTING) && (READ(Y_MAX_PIN)^Y_MAX_ENDSTOP_INVERTING)) {
+        endstop_test_error('Y');
+      }
+    #endif
+    #if HAS_Z_MIN && HAS_Z_MAX
+      if ((READ(Z_MIN_PIN)^Z_MIN_ENDSTOP_INVERTING) && (READ(Z_MAX_PIN)^Z_MAX_ENDSTOP_INVERTING)) {
+        endstop_test_error('Z');
+      }
+    #endif
+
+    #if HAS_X_MIN
+      if (READ(X_MIN_PIN)^X_MIN_ENDSTOP_INVERTING) {
+        free_endstop(X_AXIS, 1);
+      }
+      if (READ(X_MIN_PIN)^X_MIN_ENDSTOP_INVERTING) {
+        endstop_free_error( 'X' );
+      }
+    #endif
+    #if HAS_X_MAX
+      if (READ(X_MAX_PIN)^X_MAX_ENDSTOP_INVERTING) {
+        free_endstop(X_AXIS, -1);
+      }
+      if (READ(X_MAX_PIN)^X_MAX_ENDSTOP_INVERTING) {
+        endstop_free_error( 'X' );
+      }
+    #endif
+    #if HAS_Y_MIN
+      if (READ(Y_MIN_PIN)^Y_MIN_ENDSTOP_INVERTING) {
+        free_endstop(Y_AXIS, 1);
+      }
+      if (READ(Y_MIN_PIN)^Y_MIN_ENDSTOP_INVERTING) {
+        endstop_free_error( 'Y' );
+      }
+    #endif
+    #if HAS_Y_MAX
+      if (READ(Y_MAX_PIN)^Y_MAX_ENDSTOP_INVERTING) {
+        free_endstop(Y_AXIS, -1);
+      }
+      if (READ(Y_MAX_PIN)^Y_MAX_ENDSTOP_INVERTING) {
+        endstop_free_error( 'Y' );
+      }
+    #endif
+    #if HAS_Z_MIN
+      if (READ(Z_MIN_PIN)^Z_MIN_ENDSTOP_INVERTING) {
+        free_endstop(Z_AXIS, 1);
+      }
+      if (READ(Z_MIN_PIN)^Z_MIN_ENDSTOP_INVERTING) {
+        endstop_free_error( 'Z' );
+      }
+    #endif
+    #if HAS_Z_MAX
+      if (READ(Z_MAX_PIN)^Z_MAX_ENDSTOP_INVERTING) {
+        free_endstop(Z_AXIS, -1);
+      }
+      if (READ(Z_MAX_PIN)^Z_MAX_ENDSTOP_INVERTING) {
+        endstop_free_error( 'Z' );
+      }
+    #endif
+  }
+#endif
+
 /**
  * Marlin entry-point: Set up before the program loop
  *  - Set up the kill pin, filament runout, power hold
@@ -726,6 +850,10 @@ void setup() {
   #ifdef STAT_LED_BLUE
     pinMode(STAT_LED_BLUE, OUTPUT);
     digitalWrite(STAT_LED_BLUE, LOW); // turn it off
+  #endif
+
+  #ifdef ENDSTOP_SELFTEST
+    selftest_endstops();
   #endif
 }
 
@@ -1008,26 +1136,6 @@ bool code_seen(char code) {
   seen_pointer = strchr(current_command_args, code);
   return (seen_pointer != NULL); // Return TRUE if the code-letter was found
 }
-
-#define DEFINE_PGM_READ_ANY(type, reader)       \
-  static inline type pgm_read_any(const type *p)  \
-  { return pgm_read_##reader##_near(p); }
-
-DEFINE_PGM_READ_ANY(float,       float);
-DEFINE_PGM_READ_ANY(signed char, byte);
-
-#define XYZ_CONSTS_FROM_CONFIG(type, array, CONFIG) \
-  static const PROGMEM type array##_P[3] =        \
-      { X_##CONFIG, Y_##CONFIG, Z_##CONFIG };     \
-  static inline type array(int axis)          \
-  { return pgm_read_any(&array##_P[axis]); }
-
-XYZ_CONSTS_FROM_CONFIG(float, base_min_pos,   MIN_POS);
-XYZ_CONSTS_FROM_CONFIG(float, base_max_pos,   MAX_POS);
-XYZ_CONSTS_FROM_CONFIG(float, base_home_pos,  HOME_POS);
-XYZ_CONSTS_FROM_CONFIG(float, max_length,     MAX_LENGTH);
-XYZ_CONSTS_FROM_CONFIG(float, home_bump_mm,   HOME_BUMP_MM);
-XYZ_CONSTS_FROM_CONFIG(signed char, home_dir, HOME_DIR);
 
 #if ENABLED(DUAL_X_CARRIAGE)
 

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -315,8 +315,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 #define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/Felix/Configuration_DUAL.h
+++ b/Marlin/example_configurations/Felix/Configuration_DUAL.h
@@ -312,8 +312,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 #define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -325,8 +325,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -328,8 +328,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true;  // set to true to invert the logic o
 const bool Y_MAX_ENDSTOP_INVERTING = true;  // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true;  // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 #define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -348,8 +348,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 #define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -333,8 +333,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -327,8 +327,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -341,8 +341,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -353,8 +353,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 #define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -325,8 +325,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -333,8 +333,25 @@ const bool X_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 const bool Y_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -368,8 +368,25 @@ const bool X_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 const bool Y_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 #define DISABLE_MIN_ENDSTOPS // Deltas only use min endstops for probing.
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -368,8 +368,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 #define DISABLE_MIN_ENDSTOPS // Deltas only use min endstops for probing.
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -368,8 +368,25 @@ const bool X_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 const bool Y_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS // Deltas only use min endstops for probing.
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -355,8 +355,25 @@ const bool X_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 const bool Y_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS // Deltas only use min endstops for probing.
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -336,8 +336,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -323,8 +323,25 @@ const bool X_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 const bool Y_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
 const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the logic of the endstop.
+
+// "No unused endstop shall appear in M119!" Disable unused endstops.
 //#define DISABLE_MAX_ENDSTOPS
 //#define DISABLE_MIN_ENDSTOPS
+
+//#define DISABLE_XMIN_ENDSTOP
+//#define DISABLE_XMAX_ENDSTOP
+//#define DISABLE_YMIN_ENDSTOP
+//#define DISABLE_YMAX_ENDSTOP
+//#define DISABLE_ZMIN_ENDSTOP
+//#define DISABLE_ZMAX_ENDSTOP
+
+// The endstop setup can be checked during boot.
+// It is tested if both endstops of an axis are triggered at the same time.
+// It is tested i a triggered endstopp can be freed by moving the tool HOME_BUMP_MM to the mid.
+// The first time you activate this, boot with the tool in mid air.
+// If your tool moves correct ?_ENDSTOP_INVERTING.
+// If your tool moves toward the endstop, correct ?_ENDSTOP_INVERTING and change INVERT_?_DIR.
+//#define ENDSTOP_SELFTEST
 
 // If you want to enable the Z probe pin, but disable its use, uncomment the line below.
 // This only affects a Z probe endstop if you have separate Z min endstop as well and have

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -219,6 +219,7 @@
 #endif
 
 #if ENABLED(DISABLE_YMAX_ENDSTOP)
+  #undef Y_MAX_PIN
   #define Y_MAX_PIN          -1
 #endif
 


### PR DESCRIPTION
Simplify to disable endstops switch by switch.
Add configurable endstop test during boot time.
  Test if two endstops on an axis are triggered at the same time.
  Test if a triggered endstop can be freed.

Adressing: https://github.com/MarlinFirmware/Marlin/issues/2965, https://github.com/MarlinFirmware/Marlin/issues/2946, 
https://github.com/MarlinFirmware/Marlin/issues/2947.
The test uses:
~686 byte with no disabled endstops.
~457 byte with the more typical 3 endstops
By the way. Every disabled endstop saves ~287 bytes without the tests, ~308 with the tests.
