### PR TITLE
CONTINUE_BUTTON

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1232,6 +1232,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -1232,6 +1232,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -1215,6 +1215,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -1213,6 +1213,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -1224,6 +1224,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -1226,6 +1226,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -1249,6 +1249,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -1232,6 +1232,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -1232,6 +1232,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -1240,6 +1240,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -1253,6 +1253,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -1224,6 +1224,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -1232,6 +1232,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -1325,6 +1325,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -1319,6 +1319,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -1322,6 +1322,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -1322,6 +1322,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -1325,6 +1325,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -1235,6 +1235,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -1226,6 +1226,14 @@
 //
 //#define SAV_3DLCD
 
+// CONTINUE_BUTTON_FEATURE defines a button, connected to CONTINUE_PIN,
+// for user interaction in case you have no display or panel.
+// To continue in a M0/M1, ...
+// When a BEEPER_PIN is defined beeps for one second.
+// Lights a LED while waiting if LED_PIN is defined.
+//#define CONTINUE_BUTTON_FEATURE
+//#define CONTINUE_PIN 35
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================


### PR DESCRIPTION
CONTINUE_BUTTON defines a button for user interaction in case you have no display or panel.
To continue in a M0/M1, filament change, ...
When a BEEPER_PIN is defined beeps for one second.
Lights a LED while waiting if LED_PIN is defined.

`wait_for_user(millis_t until)` is the central function. It waits ms milliseconds
or until a button is clicked. The button is ether the click-button of a panel, or the newly introduced `CONTINUE_BUTTON`.

Example for the usage is M0/M1.
