### PR TITLE
Some more probe cleanup

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1173,17 +1173,15 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define NUM_SERVOS 3 // Servo index starts with 0 for M280 command
 
+// Delay (in microseconds) before the next move will start, to give the servo time to reach its target angle.
+// 300ms is a good value but you can try less delay.
+// If the servo can't reach the requested position, increase it.
+#define SERVO_DELAY 300
+
 // Servo deactivation
 //
 // With this option servos are powered only during movement, then turned off to prevent jitter.
 //#define DEACTIVATE_SERVOS_AFTER_MOVE
-
-#if ENABLED(DEACTIVATE_SERVOS_AFTER_MOVE)
-  // Delay (in microseconds) before turning the servo off. This depends on the servo speed.
-  // 300ms is a good value but you can try less delay.
-  // If the servo can't reach the requested position, increase it.
-  #define SERVO_DEACTIVATION_DELAY 300
-#endif
 
 /**********************************************************************\
  * Support for a filament diameter sensor

--- a/Marlin/servo.cpp
+++ b/Marlin/servo.cpp
@@ -58,7 +58,7 @@
  write()     - Sets the servo angle in degrees.  (invalid angle that is valid as pulse in microseconds is treated as microseconds)
  writeMicroseconds() - Sets the servo pulse width in microseconds
  move(pin, angle) - Sequence of attach(pin), write(angle).
-                    With DEACTIVATE_SERVOS_AFTER_MOVE it waits SERVO_DEACTIVATION_DELAY and detaches.
+                    With DEACTIVATE_SERVOS_AFTER_MOVE it waits SERVO_DELAY and detaches.
  read()      - Gets the last written servo pulse width as an angle between 0 and 180.
  readMicroseconds()   - Gets the last written servo pulse width in microseconds. (was read_us() in first release)
  attached()  - Returns true if there is a servo attached.
@@ -238,6 +238,7 @@ static void finISR(timer16_Sequence_t timer) {
     }
   #else //!WIRING
     // For arduino - in future: call here to a currently undefined function to reset the timer
+	UNUSED(timer);
   #endif
 }
 
@@ -324,8 +325,8 @@ bool Servo::attached() { return servo_info[this->servoIndex].Pin.isActive; }
 void Servo::move(int value) {
   if (this->attach(0) >= 0) {
     this->write(value);
+    delay(SERVO_DELAY);
     #if ENABLED(DEACTIVATE_SERVOS_AFTER_MOVE)
-      delay(SERVO_DEACTIVATION_DELAY);
       this->detach();
     #endif
   }

--- a/Marlin/servo.h
+++ b/Marlin/servo.h
@@ -63,7 +63,7 @@
    attached()  - Returns true if there is a servo attached.
    detach()    - Stops an attached servos from pulsing its i/o pin.
    move(angle) - Sequence of attach(0), write(angle),
-                   With DEACTIVATE_SERVOS_AFTER_MOVE wait SERVO_DEACTIVATION_DELAY and detach.
+                   With DEACTIVATE_SERVOS_AFTER_MOVE wait SERVO_DELAY and detach.
  */
 
 #ifndef servo_h
@@ -147,7 +147,7 @@ class Servo {
     void writeMicroseconds(int value); // write pulse width in microseconds
     void move(int value);              // attach the servo, then move to value
                                        // if value is < 200 it is treated as an angle, otherwise as pulse width in microseconds
-                                       // if DEACTIVATE_SERVOS_AFTER_MOVE wait SERVO_DEACTIVATION_DELAY, then detach
+                                       // if DEACTIVATE_SERVOS_AFTER_MOVE wait SERVO_DELAY, then detach
     int read();                        // returns current pulse width as an angle between 0 and 180 degrees
     int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
     bool attached();                   // return true if this servo is attached, otherwise false


### PR DESCRIPTION
``` diff
-    if (probe_action & ProbeStow) {
+    if (stow) {
       stow_z_probe();
     }
+    else {
+      do_probe_raise(max(current_position[Z_AXIS],Z_RAISE_BETWEEN_PROBINGS));
+    }
```

is the key idea in `probe_pt()`.
The rest is more or less the concequences.

And a simple servo tweak to prevent the probe from moving before the servo is at its target angle.

Not very well tested.

Best viewd with https://github.com/AnHardt/Marlin/pull/48/files?diff=unified?w=1
