### PR TITLE
Simplify dock_sled()

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -255,6 +255,7 @@
 
     #define HAS_LCD_CONTRAST ( \
         ENABLED(MAKRPANEL) \
+     || ENABLED(CARTESIO_UI) \
      || ENABLED(VIKI2) \
      || ENABLED(miniVIKI) \
      || ENABLED(ELB_FULL_GRAPHIC_CONTROLLER) \

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1713,10 +1713,7 @@ static void clean_up_after_endstop_or_probe_move() {
       z_dest -= zprobe_zoffset;
 
     if (z_dest > current_position[Z_AXIS]) {
-      float old_feedrate = feedrate;
-      feedrate = homing_feedrate[Z_AXIS];
       do_blocking_move_to_z(z_dest);
-      feedrate = old_feedrate;
     }
   }
 
@@ -1795,9 +1792,7 @@ static void clean_up_after_endstop_or_probe_move() {
     if (endstops.z_probe_enabled) return;
 
     // Make room for probe
-    #if _Z_RAISE_PROBE_DEPLOY_STOW > 0
-      do_probe_raise(_Z_RAISE_PROBE_DEPLOY_STOW);
-    #endif
+    do_probe_raise(_Z_RAISE_PROBE_DEPLOY_STOW);
 
     #if ENABLED(Z_PROBE_SLED)
 
@@ -1899,9 +1894,7 @@ static void clean_up_after_endstop_or_probe_move() {
     if (!endstops.z_probe_enabled) return;
 
     // Make more room for the servo
-    #if _Z_RAISE_PROBE_DEPLOY_STOW > 0
-      do_probe_raise(_Z_RAISE_PROBE_DEPLOY_STOW);
-    #endif
+    do_probe_raise(_Z_RAISE_PROBE_DEPLOY_STOW);
 
     #if ENABLED(Z_PROBE_SLED)
 
@@ -2839,28 +2832,33 @@ inline void gcode_G28() {
 
     #elif defined(MIN_Z_HEIGHT_FOR_HOMING) && MIN_Z_HEIGHT_FOR_HOMING > 0
 
-      // Raise Z before homing any other axes and z is not already high enough (never lower z)
-      if (current_position[Z_AXIS] <= MIN_Z_HEIGHT_FOR_HOMING) {
-        destination[Z_AXIS] = MIN_Z_HEIGHT_FOR_HOMING;
-        feedrate = planner.max_feedrate[Z_AXIS] * 60;  // feedrate (mm/m) = max_feedrate (mm/s)
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) {
-            SERIAL_ECHOPAIR("Raise Z (before homing) to ", (MIN_Z_HEIGHT_FOR_HOMING));
-            SERIAL_EOL;
-            DEBUG_POS("> (home_all_axis || homeZ)", current_position);
-            DEBUG_POS("> (home_all_axis || homeZ)", destination);
-          }
-        #endif
-        line_to_destination();
-        stepper.synchronize();
+      #if HAS_BED_PROBE
+        do_probe_raise(MIN_Z_HEIGHT_FOR_HOMING);
+        destination[Z_AXIS] = current_position[Z_AXIS];
+      #else
+        // Raise Z before homing any other axes and z is not already high enough (never lower z)
+        if (current_position[Z_AXIS] <= MIN_Z_HEIGHT_FOR_HOMING) {
+          destination[Z_AXIS] = MIN_Z_HEIGHT_FOR_HOMING;
+          feedrate = planner.max_feedrate[Z_AXIS] * 60;  // feedrate (mm/m) = max_feedrate (mm/s)
+          #if ENABLED(DEBUG_LEVELING_FEATURE)
+            if (DEBUGGING(LEVELING)) {
+              SERIAL_ECHOPAIR("Raise Z (before homing) to ", (MIN_Z_HEIGHT_FOR_HOMING));
+              SERIAL_EOL;
+              DEBUG_POS("> (home_all_axis || homeZ)", current_position);
+              DEBUG_POS("> (home_all_axis || homeZ)", destination);
+            }
+          #endif
+          line_to_destination();
+          stepper.synchronize();
 
-        /**
-         * Update the current Z position even if it currently not real from
-         * Z-home otherwise each call to line_to_destination() will want to
-         * move Z-axis by MIN_Z_HEIGHT_FOR_HOMING.
-         */
-        current_position[Z_AXIS] = destination[Z_AXIS];
-      }
+          /**
+           * Update the current Z position even if it currently not real from
+           * Z-home otherwise each call to line_to_destination() will want to
+           * move Z-axis by MIN_Z_HEIGHT_FOR_HOMING.
+           */
+          current_position[Z_AXIS] = destination[Z_AXIS];
+        }
+      #endif
     #endif
 
     #if ENABLED(QUICK_HOME)
@@ -2917,7 +2915,12 @@ inline void gcode_G28() {
 
     #if ENABLED(HOME_Y_BEFORE_X)
       // Home Y
-      if (home_all_axis || homeY) HOMEAXIS(Y);
+      if (home_all_axis || homeY) {
+        HOMEAXIS(Y);
+        #if ENABLED(DEBUG_LEVELING_FEATURE)
+          if (DEBUGGING(LEVELING)) DEBUG_POS("> homeY", current_position);
+        #endif
+      }
     #endif
 
     // Home X

--- a/Marlin/language_an.h
+++ b/Marlin/language_an.h
@@ -142,7 +142,8 @@
 #define MSG_INIT_SDCARD                     "Encetan. tarcheta"
 #define MSG_CNG_SDCARD                      "Cambiar tarcheta"
 #define MSG_ZPROBE_OUT                      "Z probe out. bed"
-#define MSG_YX_UNHOMED                      "Home X/Y before Z"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Z Offset"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_bg.h
+++ b/Marlin/language_bg.h
@@ -143,7 +143,8 @@
 #define MSG_INIT_SDCARD                     "Иниц. SD-Карта"
 #define MSG_CNG_SDCARD                      "Смяна SD-Карта"
 #define MSG_ZPROBE_OUT                      "Z-сондата е извадена"
-#define MSG_YX_UNHOMED                      "Задайте X/Y преди Z"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Z Отстояние"
 #define MSG_BABYSTEP_X                      "Министъпка X"
 #define MSG_BABYSTEP_Y                      "Министъпка Y"

--- a/Marlin/language_ca.h
+++ b/Marlin/language_ca.h
@@ -143,7 +143,8 @@
 #define MSG_INIT_SDCARD                     "Iniciant SD"
 #define MSG_CNG_SDCARD                      "Canviar SD"
 #define MSG_ZPROBE_OUT                      "Z probe out. bed"
-#define MSG_YX_UNHOMED                      "Home X/Y abans Z"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Z Offset"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_cn.h
+++ b/Marlin/language_cn.h
@@ -142,7 +142,8 @@
 #define MSG_INIT_SDCARD                     "Init. SD card"
 #define MSG_CNG_SDCARD                      "Change SD card"
 #define MSG_ZPROBE_OUT                      "Z probe out. bed"
-#define MSG_YX_UNHOMED                      "Home X/Y before Z"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Z Offset"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_cz.h
+++ b/Marlin/language_cz.h
@@ -174,8 +174,8 @@
 #define MSG_INIT_SDCARD                     "Nacist SD kartu"
 #define MSG_CNG_SDCARD                      "Vymenit SD kartu"
 #define MSG_ZPROBE_OUT                      "Sonda Z mimo podl"
-#define MSG_YX_UNHOMED                      "Domu X/Y pred Z"
-#define MSG_XYZ_UNHOMED                     "Domu XYZ prvni"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Z ofset"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_da.h
+++ b/Marlin/language_da.h
@@ -170,8 +170,8 @@
 #define MSG_INIT_SDCARD                     "Init. SD card"
 #define MSG_CNG_SDCARD                      "Skift SD kort"
 #define MSG_ZPROBE_OUT                      "Probe udenfor plade"
-#define MSG_YX_UNHOMED                      "Home X/Y før Z"
-#define MSG_XYZ_UNHOMED                     "Home XYZ first"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Z Offset"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -145,7 +145,8 @@
 #define MSG_INIT_SDCARD                     "SD-Karte erkennen"  // Manually initialize the SD-card via user interface
 #define MSG_CNG_SDCARD                      "SD-Karte getauscht" // SD-card changed by user. For machines with no autocarddetect. Both send "M21"
 #define MSG_ZPROBE_OUT                      "Sensor ausserhalb"
-#define MSG_YX_UNHOMED                      "X/Y vor Z homen!"
+#define MSG_HOME                            "Vorher"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "homen"
 #define MSG_ZPROBE_ZOFFSET                  "Z Offset"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -445,11 +445,11 @@
 #ifndef MSG_ZPROBE_OUT
   #define MSG_ZPROBE_OUT                      "Z probe out. bed"
 #endif
-#ifndef MSG_YX_UNHOMED
-  #define MSG_YX_UNHOMED                      "Home X/Y before Z"
+#ifndef MSG_HOME
+  #define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
 #endif
-#ifndef MSG_XYZ_UNHOMED
-  #define MSG_XYZ_UNHOMED                     "Home XYZ first"
+#ifndef MSG_FIRST
+  #define MSG_FIRST                           "first"
 #endif
 #ifndef MSG_ZPROBE_ZOFFSET
   #define MSG_ZPROBE_ZOFFSET                  "Z Offset"

--- a/Marlin/language_es.h
+++ b/Marlin/language_es.h
@@ -169,8 +169,8 @@
 #define MSG_INIT_SDCARD                     "Iniciando tarjeta"
 #define MSG_CNG_SDCARD                      "Cambiar tarjeta"
 #define MSG_ZPROBE_OUT                      "Sonda Z fuera"
-#define MSG_YX_UNHOMED                      "Reiniciar X/Y y Z"
-#define MSG_XYZ_UNHOMED                     "Reiniciar XYZ"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Desfase Z"
 #define MSG_BABYSTEP_X                      "Micropaso X"
 #define MSG_BABYSTEP_Y                      "Micropaso Y"

--- a/Marlin/language_eu.h
+++ b/Marlin/language_eu.h
@@ -142,7 +142,8 @@
 #define MSG_INIT_SDCARD                     "Hasieratu txartela"
 #define MSG_CNG_SDCARD                      "Aldatu txartela"
 #define MSG_ZPROBE_OUT                      "Z ohe hasiera"
-#define MSG_YX_UNHOMED                      "Posizio ezezaguna"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Z konpentsatu"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_fi.h
+++ b/Marlin/language_fi.h
@@ -142,7 +142,8 @@
 #define MSG_INIT_SDCARD                     "Init. SD-Card"
 #define MSG_CNG_SDCARD                      "Change SD-Card"
 #define MSG_ZPROBE_OUT                      "Z probe out. bed"
-#define MSG_YX_UNHOMED                      "Home X/Y before Z"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Z Offset"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -145,7 +145,8 @@
 #define MSG_INIT_SDCARD                     "Init. la carte SD"
 #define MSG_CNG_SDCARD                      "Changer de carte"
 #define MSG_ZPROBE_OUT                      "Z sonde exte. lit"
-#define MSG_YX_UNHOMED                      "Rev. dans XY av.Z"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Decalage Z"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_gl.h
+++ b/Marlin/language_gl.h
@@ -170,8 +170,8 @@
 #define MSG_INIT_SDCARD                     "Iniciando SD"
 #define MSG_CNG_SDCARD                      "Cambiar SD"
 #define MSG_ZPROBE_OUT                      "Sonda-Z sen cama"
-#define MSG_YX_UNHOMED                      "X/Y antes que Z"
-#define MSG_XYZ_UNHOMED                     "Orixe XYZ antes"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Offset Z"
 #define MSG_BABYSTEP_X                      "Micropaso X"
 #define MSG_BABYSTEP_Y                      "Micropaso Y"

--- a/Marlin/language_hr.h
+++ b/Marlin/language_hr.h
@@ -171,8 +171,8 @@
 #define MSG_INIT_SDCARD                     "Init. SD karticu"
 #define MSG_CNG_SDCARD                      "Promijeni SD karticu"
 #define MSG_ZPROBE_OUT                      "Z probe out. bed"
-#define MSG_YX_UNHOMED                      "Home-aj X/Y prije Z"
-#define MSG_XYZ_UNHOMED                     "Home-aj XYZ prvo"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Z Offset"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_it.h
+++ b/Marlin/language_it.h
@@ -150,8 +150,8 @@
 #define MSG_INIT_SDCARD                     "Iniz. SD-Card"
 #define MSG_CNG_SDCARD                      "Cambia SD-Card"
 #define MSG_ZPROBE_OUT                      "Z probe out. bed"
-#define MSG_YX_UNHOMED                      "Home X/Y prima di Z"
-#define MSG_XYZ_UNHOMED                     "Home XYZ prima"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Z Offset"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_kana.h
+++ b/Marlin/language_kana.h
@@ -184,6 +184,10 @@
 #define MSG_INIT_SDCARD                     "SD\xb6\xb0\xc4\xde\xbb\xb2\xd6\xd0\xba\xd0"                       // "SDｶｰﾄﾞｻｲﾖﾐｺﾐ" ("Init. SD card")
 #define MSG_CNG_SDCARD                      "SD\xb6\xb0\xc4\xde\xba\xb3\xb6\xdd"                               // "SDｶｰﾄﾞｺｳｶﾝ" ("Change SD card")
 #define MSG_ZPROBE_OUT                      "Z\xcc\xdf\xdb\xb0\xcc\xde\x20\xcd\xde\xaf\xc4\xde\xb6\xde\xb2"    // "Zﾌﾟﾛｰﾌﾞ ﾍﾞｯﾄﾞｶﾞｲ" ("Z probe out. bed")
+
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
+/*
 #if LCD_WIDTH < 20
   #define MSG_YX_UNHOMED                    "\xbb\xb7\xc6X/Y\xa6\xcc\xaf\xb7\xbb\xbe\xd6"                                   // "ｻｷﾆX/Yｦﾌｯｷｻｾﾖ" ("Home X/Y before Z")
   #define MSG_XYZ_UNHOMED                   "\xbb\xb7\xc6\xb9\xde\xdd\xc3\xdd\xcc\xaf\xb7\xa6\xbe\xd6"                      // "ｻｷﾆｹﾞﾝﾃﾝﾌｯｷｦｾﾖ" ("Home XYZ first")
@@ -191,6 +195,7 @@
   #define MSG_YX_UNHOMED                    "\xbb\xb7\xc6X/Y\xa6\xcc\xaf\xb7\xbb\xbe\xc3\xb8\xc0\xde\xbb\xb2"               // "ｻｷﾆX/Yｦﾌｯｷｻｾﾃｸﾀﾞｻｲ" ("Home X/Y before Z")
   #define MSG_XYZ_UNHOMED                   "\xbb\xb7\xc6\xb9\xde\xdd\xc3\xdd\xcc\xaf\xb7\xa6\xbc\xc3\xb8\xc0\xde\xbb\xb2"  // "ｻｷﾆｹﾞﾝﾃﾝﾌｯｷｦｼﾃｸﾀﾞｻｲ" ("Home XYZ first")
 #endif
+*/
 #define MSG_ZPROBE_ZOFFSET                  "Z\xb5\xcc\xbe\xaf\xc4"                                            // "Zｵﾌｾｯﾄ" ("Z Offset")
 #define MSG_BABYSTEP_X                      "X\xbc\xde\xb8\x20\xcb\xde\xc4\xde\xb3"                            // "Xｼﾞｸ ﾋﾞﾄﾞｳ" ("Babystep X")
 #define MSG_BABYSTEP_Y                      "Y\xbc\xde\xb8\x20\xcb\xde\xc4\xde\xb3"                            // "Yｼﾞｸ ﾋﾞﾄﾞｳ" ("Babystep Y")

--- a/Marlin/language_kana_utf8.h
+++ b/Marlin/language_kana_utf8.h
@@ -155,8 +155,8 @@
 #define MSG_INIT_SDCARD                     "SDカードサイヨミコミ"             // "Init. SD card"
 #define MSG_CNG_SDCARD                      "SDカードコウカン"               // "Change SD card"
 #define MSG_ZPROBE_OUT                      "Zプローブ ベッドガイ"            // "Z probe out. bed"
-#define MSG_YX_UNHOMED                      "サキニX/Yヲフッキサセテクダサイ"    // "Home X/Y before Z"
-#define MSG_XYZ_UNHOMED                     "サキニゲンテンフッキヲシテクダサイ"   // "Home XYZ first"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Zオフセット"                   // "Z Offset"
 #define MSG_BABYSTEP_X                      "Xジク ビドウ"                  // "Babystep X"
 #define MSG_BABYSTEP_Y                      "Yジク ビドウ"                  // "Babystep Y"

--- a/Marlin/language_nl.h
+++ b/Marlin/language_nl.h
@@ -144,7 +144,8 @@
 #define MSG_INIT_SDCARD                     "Init. SD kaart"
 #define MSG_CNG_SDCARD                      "Verv. SD Kaart"
 #define MSG_ZPROBE_OUT                      "Z probe uit. bed"
-#define MSG_YX_UNHOMED                      "Home X/Y voor Z"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Z Offset"
 #define MSG_BABYSTEP_X                      "Babystap X"
 #define MSG_BABYSTEP_Y                      "Babystap Y"

--- a/Marlin/language_pl.h
+++ b/Marlin/language_pl.h
@@ -167,7 +167,8 @@
 #define MSG_INIT_SDCARD                     "Inicjal. karty SD"
 #define MSG_CNG_SDCARD                      "Zmiana karty SD"
 #define MSG_ZPROBE_OUT                      "Sonda Z za lozem"
-#define MSG_YX_UNHOMED                      "Wroc w XY przed Z"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Offset Z"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -144,7 +144,8 @@
 #define MSG_INIT_SDCARD                     "Iniciar SD"
 #define MSG_CNG_SDCARD                      "Trocar SD"
 #define MSG_ZPROBE_OUT                      "Son. fora da mesa"
-#define MSG_YX_UNHOMED                      "Pos. Desconhecida"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Deslocamento no Z"
 #define MSG_BABYSTEP_X                      "Passinho X"
 #define MSG_BABYSTEP_Y                      "Passinho Y"

--- a/Marlin/language_pt-br_utf8.h
+++ b/Marlin/language_pt-br_utf8.h
@@ -144,7 +144,8 @@
 #define MSG_INIT_SDCARD                     "Iniciar SD"
 #define MSG_CNG_SDCARD                      "Trocar SD"
 #define MSG_ZPROBE_OUT                      "Son. fora da mesa"
-#define MSG_YX_UNHOMED                      "Pos. Desconhecida"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Deslocamento no Z"
 #define MSG_BABYSTEP_X                      "Passinho X"
 #define MSG_BABYSTEP_Y                      "Passinho Y"

--- a/Marlin/language_pt.h
+++ b/Marlin/language_pt.h
@@ -152,7 +152,8 @@
 #define MSG_INIT_SDCARD                     "Inici. cartao SD"
 #define MSG_CNG_SDCARD                      "Trocar cartao SD"
 #define MSG_ZPROBE_OUT                      "Sensor fora/base"
-#define MSG_YX_UNHOMED                      "XY antes de Z"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Desvio Z"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"

--- a/Marlin/language_pt_utf8.h
+++ b/Marlin/language_pt_utf8.h
@@ -152,7 +152,8 @@
 #define MSG_INIT_SDCARD                     "Inici. cartão SD"
 #define MSG_CNG_SDCARD                      "Trocar cartão SD"
 #define MSG_ZPROBE_OUT                      "Sensor fora/base"
-#define MSG_YX_UNHOMED                      "XY antes de Z"
+#define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X  MSG_Y  MSG_Z " " MSG_FIRST
+#define MSG_FIRST                           "first"
 #define MSG_ZPROBE_ZOFFSET                  "Desvio Z"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"


### PR DESCRIPTION
Simplify dock_sled()
`dock_sled()` is never called with offset parameter - remove it.
We move x only - so only that needs to be homed. Consequence is - we can home to z-min now with a sled probe!
Feedrates are set and restored in `do_blocking_move()`.
We already checked if the probe is deployed/stowed in deploy/stow_probe.

```
if (z_loc < _Z_RAISE_PROBE_DEPLOY_STOW + 5) z_loc = _Z_RAISE_PROBE_DEPLOY_STOW;
```

makes no sense - remove.
Now the raise is the same for deploy/stow -> move before the if - and remove at all because already done in deploy/stow_probe.
Replace the if with a ternary.
Instead writing LOW/HIGH use the boolean `stow` we already have.

There is no reason for not using the sled probe in G29/M48 with 'E'.
It takes a while but works. (tested!)

universalize axis_unhomed_error()

Some more tweaks
Feedrates are set in `do_blocking_move()`
`_Z_RAISE_PROBE_DEPLOY_STOW` is always defined here.
If `HAS_BED_PROBE` is defined in G28 we have a shothand.
Debug output for home y for the `HOME_Y_BEFORE_X` case.
