### PR TITLE
Planner timing

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -638,6 +638,32 @@ void Planner::check_axes_activity() {
 
 #endif // PLANNER_LEVELING
 
+millis_t times[4];
+millis_t times_min = 10000000;
+millis_t times_max = 0;
+float times_avg = 0;
+millis_t times_n = 0;
+
+void planner_report(void) {
+  millis_t t = times[3]-times[0] - (times[2]-times[1]);
+  times_min = min(times_min, t);
+  times_max = max(times_max, t);
+  times_avg += t;
+  times_n++;
+  
+  SERIAL_ECHO_START;
+  SERIAL_ECHOPGM("planner:");
+  SERIAL_ECHO(t);
+  SERIAL_ECHOPGM(", min:");
+  SERIAL_ECHO(times_min);
+  SERIAL_ECHOPGM(", avg:");
+  SERIAL_ECHO(times_avg/times_n);
+  SERIAL_ECHOPGM(", max:");
+  SERIAL_ECHO(times_max);
+  SERIAL_EOL;
+}
+
+
 /**
  * Planner::_buffer_line
  *
@@ -650,6 +676,9 @@ void Planner::check_axes_activity() {
  *  extruder    - target extruder
  */
 void Planner::_buffer_line(const float &a, const float &b, const float &c, const float &e, float fr_mm_s, const uint8_t extruder) {
+
+
+times[0] = millis();
 
   // The target position of the tool in absolute steps
   // Calculate target position in absolute steps
@@ -763,7 +792,9 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
 
   // If the buffer is full: good! That means we are well ahead of the robot.
   // Rest here until there is room in the buffer.
+  times[1] = millis();
   while (block_buffer_tail == next_buffer_head) idle();
+  times[2] = millis();
 
   // Prepare to set up new block
   block_t* block = &block_buffer[block_buffer_head];
@@ -799,7 +830,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
   block->step_event_count = MAX4(block->steps[X_AXIS], block->steps[Y_AXIS], block->steps[Z_AXIS], esteps);
 
   // Bail if this is a zero-length block
-  if (block->step_event_count < MIN_STEPS_PER_SEGMENT) return;
+  if (block->step_event_count < MIN_STEPS_PER_SEGMENT) {times[3] = millis(); planner_report(); return;};
 
   // For a mixing extruder, get a magnified step_event_count for each
   #if ENABLED(MIXING_EXTRUDER)
@@ -1352,6 +1383,9 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
 
   stepper.wake_up();
 
+  times[3] = millis();
+  planner_report();
+  
 } // buffer_line()
 
 /**

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -338,7 +338,7 @@ void Stepper::isr() {
   CBI(TIMSK0, OCIE0B); //Temperature ISR
   DISABLE_STEPPER_DRIVER_INTERRUPT();
   sei();
-  
+  cleaning_buffer_counter = 2;
   if (cleaning_buffer_counter) {
     --cleaning_buffer_counter;
     current_block = NULL;


### PR DESCRIPTION
I build my own timer for the planner.

Sometimes i get similar results as @Sebastianv650, but mostly total different.
The values include the time used by the stepper interrupt.
With the same model, depending on the feedrate i can get maximum times from 4 to 20ms and averages from 2 to 8ms. Without any ADVANCE.

In a second step i minimized the time for the stepper-ISR by short cutting it.
Then, for the same model i get now max at 4ms and average at 1.73ms for the planing time + the remaining interrupts.

Sadly non of this value can be used for `MIN_BLOCK_TIME` the variation is too big.

(cc @thinkyhead, @Sebastianv650)