### PR TITLE
Fix temp-interrupt with LIN_ADVANCE

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -828,7 +828,10 @@ void Stepper::isr() {
 
     // Restore original ISR settings
     cli();
-    SBI(TIMSK0, OCIE0B);
+    if (thermalManager.in_temp_isr)
+      CBI(TIMSK0, OCIE0B);
+    else
+      SBI(TIMSK0, OCIE0B);
     ENABLE_STEPPER_DRIVER_INTERRUPT();
   }
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -60,6 +60,8 @@ int   Temperature::current_temperature_raw[HOTENDS] = { 0 },
       Temperature::current_temperature_bed_raw = 0,
       Temperature::target_temperature_bed = 0;
 
+volatile bool Temperature::in_temp_isr = false;
+
 #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
   float Temperature::redundant_temperature = 0.0;
 #endif
@@ -1489,6 +1491,8 @@ void Temperature::set_current_temp_raw() {
 ISR(TIMER0_COMPB_vect) { Temperature::isr(); }
 
 void Temperature::isr() {
+  if (in_temp_isr) return;
+  in_temp_isr = true;
   //Allow UART and stepper ISRs
   CBI(TIMSK0, OCIE0B); //Disable Temperature ISR
   sei();
@@ -1944,5 +1948,7 @@ void Temperature::isr() {
     }
   #endif
 
+  in_temp_isr = false;
   SBI(TIMSK0, OCIE0B); //re-enable Temperature ISR
+
 }

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -61,6 +61,8 @@ class Temperature {
                  current_temperature_bed_raw,
                  target_temperature_bed;
 
+    static volatile bool in_temp_isr;
+
     #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
       static float redundant_temperature;
     #endif


### PR DESCRIPTION
Error mechanism:
Let's suppose we are in 'Temperature::isr()'. 
```
  CBI(TIMSK0, OCIE0B); //Disable Temperature ISR
  sei();
```
The temperature-interrupt is disabled, but all others are enabled.

Now the temp-isr is interrupted by the `Stepper::advance_isr_scheduler()`
```
    // Disable Timer0 ISRs and enable global ISR again to capture UART events (incoming chars)
    CBI(TIMSK0, OCIE0B); // Temperature ISR
    DISABLE_STEPPER_DRIVER_INTERRUPT();
    sei();
```
temp-isr and stepper-isr are disabled.
When we leave the `Stepper::advance_isr_scheduler()` we execute
```
    // Restore original ISR settings
    cli();
    SBI(TIMSK0, OCIE0B);
    ENABLE_STEPPER_DRIVER_INTERRUPT();
```
Enable temp-isr and stepper-isr. In case we interrupted the temp-isr this does not restore the ISR settings, but enables the temp-isr falsely.
If its time for a fresh  temp-isr now, this is entered before the still on the stack temp-isr ended - the temp-isr bites its tail.

Problems:
Is temp-isr is entered multiple times the stack may overflow.
temp-isr is not made for reentering.

Symptoms:
Sampling OVERSAMPLENR+1 (or more) instead of OVERSAMPLENR samples. 
* if the temperature is low (high raw values) this may result in min-temp-error.
* if the temperature is high it looks like a sudden, and only one time, drop of temperature by about 1/17 the expected one.

Even worse and unpredictable things when the stack overfolowes