### PR TITLE
Restore 'home z in place' with Z_SAVE_HOMING

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -341,7 +341,10 @@ void GcodeSuite::G28(const bool always_home_all) {
           bltouch.init();
         #endif
         #if ENABLED(Z_SAFE_HOMING)
-          home_z_safely();
+          if (home_all)
+            home_z_safely();
+          else
+            homeaxis(Z_AXIS);
         #else
           homeaxis(Z_AXIS);
         #endif


### PR DESCRIPTION
Fixing #14530 by a feature lost in https://github.com/MarlinFirmware/Marlin/commit/c84b14c77a5c1ae277a28e1dc0bd84094efc42ec

That feature got lost that long ago (12 Sep 2016) some new features may be based on the new behavior.
Intensive testing is needed.