### PR TITLE
Repair display throttling

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2037,6 +2037,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
     if (was_enabled) DISABLE_STEPPER_DRIVER_INTERRUPT();
 
     block_buffer_runtime_us += segment_time_us;
+    block->segment_time_us = segment_time_us;
 
     if (was_enabled) ENABLE_STEPPER_DRIVER_INTERRUPT();
   #endif

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -155,7 +155,9 @@ typedef struct block_t {
     uint8_t valve_pressure, e_to_p_pressure;
   #endif
 
-  uint32_t segment_time_us;
+  #if HAS_SPI_LCD
+    uint32_t segment_time_us;
+  #endif
 
 } block_t;
 


### PR DESCRIPTION
Some time ago @thinkyhead asked in a [comment](https://github.com/MarlinFirmware/Marlin/issues/12461#issuecomment-513068344) if my display throttling code is still working. After a very brief look i [answered](https://github.com/MarlinFirmware/Marlin/issues/12461#issuecomment-513196290) it would be still in place, but a bit of debug code would show if it still works.
I suggested to look at the numbers in https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.0.x/Marlin/src/lcd/ultralcd.cpp#L986.
Since up to now, seemingly no one else did and i was away from my equipment, i did it now.
And, who wonders - it did not work. `max_display_update_time` seems to have realistic values, but during print `planner.block_buffer_runtime()` grew more and more. Consequently there was always enough time in the planner buffer to allow a display update.
The [subtraction of the time for the running block](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.0.x/Marlin/src/module/planner.h#L777) did not work because `block->segment_time_us` was never set. All operations in the planner worked on the local `segment_time_us`.
